### PR TITLE
Remove double declaration on `setValue` function

### DIFF
--- a/app/code/Icube/Snapinstmigs/Controller/Payment/Redirect.php
+++ b/app/code/Icube/Snapinstmigs/Controller/Payment/Redirect.php
@@ -579,11 +579,6 @@ class Redirect extends \Magento\Framework\App\Action\Action
         return $country_code;
     }
 
-    public function setValue($order_id){
-        $this->_coreSession->start();
-        $this->_coreSession->setMessage($order_id);
-    }
-
     private function repString($str){
         return preg_replace("/[^a-zA-Z0-9]+/", " ", $str);
     }


### PR DESCRIPTION
Double declaration of `setValue` function can raise PHP error.
This commit remove one of it