### PR TITLE
Revert "Fixing SSL Certificate Issue" to fix syntax error

### DIFF
--- a/lib/internal/veritrans-php/Veritrans/ApiRequestor.php
+++ b/lib/internal/veritrans-php/Veritrans/ApiRequestor.php
@@ -38,7 +38,7 @@ class Veritrans_ApiRequestor {
 
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt ($ch, CURLOPT_CAINFO,
-        // dirname(__FILE__) . "/../data/cacert.pem");
+        dirname(__FILE__) . "/../data/cacert.pem");
 
     $result = curl_exec($ch);
     // curl_close($ch);

--- a/lib/internal/veritrans-php/Veritrans/SnapApiRequestor.php
+++ b/lib/internal/veritrans-php/Veritrans/SnapApiRequestor.php
@@ -55,7 +55,7 @@ class Veritrans_SnapApiRequestor {
         'Authorization: Basic ' . base64_encode($server_key . ':')
       ),
       CURLOPT_RETURNTRANSFER => 1,
-      // CURLOPT_CAINFO => dirname(__FILE__) . "/../data/cacert.pem"
+      CURLOPT_CAINFO => dirname(__FILE__) . "/../data/cacert.pem"
     );
 
     // merging with Veritrans_Config::$curlOptions


### PR DESCRIPTION
Reverts Midtrans/SNAP-Magento2#12
This commit causing syntax error because of not properly tested.

TODO longterm: Should use newest veritrans php library